### PR TITLE
Add Deal/Pick Up menus and reorganize Settings panel

### DIFF
--- a/CardPhysicsPackage/Sources/CardPhysicsKit/PhysicsSettings.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/PhysicsSettings.swift
@@ -3,24 +3,23 @@ import Foundation
 @Observable
 @MainActor
 public final class PhysicsSettings: Sendable {
-    // Animation speeds (seconds)
+
+    // MARK: - Deal Animation
     public var dealDuration: Double = 0.5
-    public var pickUpDuration: Double = 0.3
-
-    // Arc heights (meters)
     public var dealArcHeight: Float = 0.15
-    public var pickUpArcHeight: Float = 0.08
-
-    // Rotation amounts (degrees)
     public var dealRotation: Double = 15.0
+
+    // MARK: - Pick Up Animation
+    public var pickUpDuration: Double = 0.3
+    public var pickUpArcHeight: Float = 0.08
     public var pickUpRotation: Double = 5.0
 
-    // Card curvature (0.0 = flat, higher = more curve)
+    // MARK: - Card Appearance
     public var cardCurvature: Float = 0.002
 
     public init() {}
 
-    // Preset configurations
+    // MARK: - Presets
     public func applyRealisticPreset() {
         dealDuration = 0.5
         pickUpDuration = 0.3


### PR DESCRIPTION
## Summary
- **Deal button** (#1): long-press context menu with 4 modes (4 Cards, 12 Cards, 20 Cards, Euchre). Euchre deals alternating 2-3/3-2 bundles. Tap repeats last-selected mode.
- **Pick Up button** (#3): long-press context menu to gather cards to any of 4 table corners with 3-phase gather → pause → lift animation. Tap repeats last-selected corner.
- **Settings panel** (#5): sliders grouped into Deal and Pick Up disclosure groups, Presets row at top, Card Appearance section, and Reset to Defaults button at bottom.

Closes #1, #3, #5

## Test plan
- [ ] Build and run on iOS 18+ simulator
- [ ] Long-press Deal button — verify 4 mode options appear
- [ ] Tap Deal — verify it deals using last-selected mode
- [ ] Select Euchre mode — verify alternating 2/3 bundle dealing pattern
- [ ] Long-press Pick Up — verify 4 corner options appear
- [ ] Tap Pick Up — verify gather-to-corner animation with last-selected corner
- [ ] Open Settings — verify Deal and Pick Up disclosure groups with grouped sliders
- [ ] Tap Reset to Defaults — verify all sliders return to realistic preset values
- [ ] Tap each preset button (Realistic, Slow Motion, Fast) — verify sliders update

🤖 Generated with [Claude Code](https://claude.com/claude-code)