### PR TITLE
Fix card texture clipping in upright fan (#50)

### DIFF
--- a/CardPhysicsApp/CardPhysicsAppUITests/CardPhysicsAppUITests.swift
+++ b/CardPhysicsApp/CardPhysicsAppUITests/CardPhysicsAppUITests.swift
@@ -14,4 +14,42 @@ final class CardPhysicsAppUITests: XCTestCase {
         continueAfterFailure = false
     }
 
+    @MainActor
+    func testCaptureInHandsFan() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Wait for app to fully load
+        sleep(3)
+
+        // Tap Deal button
+        let dealButton = app.buttons["Deal"]
+        XCTAssertTrue(dealButton.waitForExistence(timeout: 5), "Deal button not found")
+        dealButton.tap()
+
+        // Wait for dealing animation to complete (12 cards × 0.3s = 3.6s + settling)
+        sleep(6)
+
+        // Take screenshot after dealing
+        let dealScreenshot = app.windows.firstMatch.screenshot()
+        let dealAttachment = XCTAttachment(screenshot: dealScreenshot)
+        dealAttachment.name = "AfterDeal"
+        dealAttachment.lifetime = .keepAlways
+        add(dealAttachment)
+
+        // Go directly to Fan in Hands (skip Pick Up — it removes cards!)
+        let fanButton = app.buttons["Fan in Hands"]
+        XCTAssertTrue(fanButton.waitForExistence(timeout: 5), "Fan in Hands button not found")
+        fanButton.tap()
+
+        // Wait for fan animation to complete
+        sleep(4)
+
+        // Take screenshot of fanned cards
+        let fanScreenshot = app.windows.firstMatch.screenshot()
+        let fanAttachment = XCTAttachment(screenshot: fanScreenshot)
+        fanAttachment.name = "InHandsFan"
+        fanAttachment.lifetime = .keepAlways
+        add(fanAttachment)
+    }
 }

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+Dealing.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+Dealing.swift
@@ -3,32 +3,6 @@ import RealityKit
 
 extension CardPhysicsScene {
 
-// MARK: - Safe Movement Wrapper
-
-/// Safely move a card to a target transform, validating against table collision
-private func moveCardSafely(
-    _ card: Entity,
-    to transform: Transform,
-    duration: TimeInterval = 0.3,
-    timingFunction: AnimationTimingFunction = .easeInOut
-) {
-    // Get current curvature for this card (default to 0 if not tracked)
-    let curvature: Float = 0.0  // Cards in dealing are flat
-
-    // Validate transform doesn't penetrate table/rails
-    let safeTransform = CollisionUtils.validateCardTransform(
-        transform,
-        cardWidth: CardEntity3D.cardWidth,
-        cardHeight: CardEntity3D.cardHeight,
-        cardDepth: CardEntity3D.cardDepth,
-        curvature: curvature,
-        scene: nil
-    )
-
-    // Use validated transform
-    card.move(to: safeTransform, relativeTo: nil, duration: duration, timingFunction: timingFunction)
-}
-
 // MARK: - Deal Modes
 
 public func dealCards(mode: DealMode) async {
@@ -40,6 +14,8 @@ public func dealCards(mode: DealMode) async {
     cardDataMap.removeAll()
     for hand in handEntities { hand.removeFromParent() }
     handEntities.removeAll()
+
+    cardsInFanState = false
 
     createDeck(count: mode.cardCount)
 
@@ -112,124 +88,15 @@ internal func dealCardsInHands() async {
         rootEntity.addChild(hand)
     }
 
-    // Deal cards evenly to each side, then arrange in fan
-    let cardsPerSide = cards.count / 4
-    var cardsBySide: [Int: [Entity]] = [1: [], 2: [], 3: [], 4: []]
-
-    // Distribute cards
+    // Distribute cards evenly to each side
     for (index, cardIndex) in cards.indices.reversed().enumerated() {
         let card = cards[cardIndex]
         let side = [1, 2, 3, 4][index % 4]
-        cardsBySide[side]?.append(card)
         cardSideAssignments[ObjectIdentifier(card)] = side
     }
 
-    // Animate cards to their fanned positions for each side
-    for side in 1...4 {
-        guard let sideCards = cardsBySide[side] else { continue }
-
-        let fanCenter = HandEntity3D.getFanCenterPosition(side: side)
-        let cardCount = sideCards.count
-
-        for (cardIndex, card) in sideCards.enumerated() {
-            // Start cards face-down (will animate to final orientation)
-            card.orientation = simd_quatf(angle: 0, axis: [1, 0, 0])
-
-            // Calculate fan arc parameters from per-side settings
-            let sideSettings = settings.inHandsSettings(for: side)
-            let fanAngle = sideSettings.fanAngle
-            let verticalOffset = sideSettings.verticalSpacing
-            let arcRadius = sideSettings.arcRadius
-
-            // Calculate position in fan (centered around middle card)
-            let normalizedIndex = Float(cardIndex) / Float(max(cardCount - 1, 1)) // 0.0 to 1.0
-            let fanProgress = normalizedIndex - 0.5 // -0.5 to 0.5
-
-            // Calculate arc position
-            let arcAngle = fanProgress * fanAngle
-
-            // Position based on side orientation
-            var cardPosition: SIMD3<Float>
-            var cardRotation: simd_quatf
-
-            // Quaternion components for proper card orientation
-            // Side-specific base rotation: Side 1 shows faces, Sides 2-4 show backs
-            let baseRotation: simd_quatf
-            switch side {
-            case 1:
-                // Player 1 (bottom): flip face-up so camera sees faces
-                baseRotation = simd_quatf(angle: .pi, axis: [1, 0, 0])
-            case 2, 3, 4:
-                // Players 2, 3, 4: keep face-down so camera sees backs
-                baseRotation = simd_quatf(angle: 0, axis: [1, 0, 0])
-            default:
-                baseRotation = simd_quatf(angle: 0, axis: [1, 0, 0])
-            }
-
-            let tiltQuat = simd_quatf(angle: sideSettings.tiltAngle, axis: [1, 0, 0])    // Tilt cards back
-            let fanQuat = simd_quatf(angle: arcAngle, axis: [0, 1, 0]) // Fan spread
-            let offsetQuat = simd_quatf(angle: sideSettings.rotationOffset, axis: [0, 1, 0]) // Rotation offset for flipping
-
-            switch side {
-            case 1: // Bottom - fan opens upward toward table center
-                cardPosition = SIMD3(
-                    fanCenter.x + sin(arcAngle) * arcRadius,
-                    fanCenter.y + Float(cardIndex) * verticalOffset,
-                    fanCenter.z - cos(arcAngle) * arcRadius + arcRadius
-                )
-                cardRotation = offsetQuat * fanQuat * tiltQuat * baseRotation
-
-            case 2: // Left - fan opens toward table center
-                cardPosition = SIMD3(
-                    fanCenter.x + cos(arcAngle) * arcRadius - arcRadius,
-                    fanCenter.y + Float(cardIndex) * verticalOffset,
-                    fanCenter.z + sin(arcAngle) * arcRadius
-                )
-                let sideQuat2 = simd_quatf(angle: .pi / 2, axis: [0, 1, 0])
-                cardRotation = sideQuat2 * offsetQuat * fanQuat * tiltQuat * baseRotation
-
-            case 3: // Top - fan opens toward table center
-                cardPosition = SIMD3(
-                    fanCenter.x - sin(arcAngle) * arcRadius,
-                    fanCenter.y + Float(cardIndex) * verticalOffset,
-                    fanCenter.z + cos(arcAngle) * arcRadius - arcRadius
-                )
-                let sideQuat3 = simd_quatf(angle: .pi, axis: [0, 1, 0])
-                cardRotation = sideQuat3 * offsetQuat * fanQuat * tiltQuat * baseRotation
-
-            case 4: // Right - fan opens toward table center
-                cardPosition = SIMD3(
-                    fanCenter.x - cos(arcAngle) * arcRadius + arcRadius,
-                    fanCenter.y + Float(cardIndex) * verticalOffset,
-                    fanCenter.z - sin(arcAngle) * arcRadius
-                )
-                let sideQuat4 = simd_quatf(angle: -.pi / 2, axis: [0, 1, 0])
-                cardRotation = sideQuat4 * offsetQuat * fanQuat * tiltQuat * baseRotation
-
-            default:
-                cardPosition = fanCenter
-                cardRotation = offsetQuat * baseRotation
-            }
-
-            // Animate card to position (kinematic mode for smooth animation)
-            if var physicsBody = card.components[PhysicsBodyComponent.self] {
-                physicsBody.mode = .kinematic
-                card.components[PhysicsBodyComponent.self] = physicsBody
-            }
-
-            // Stagger the animation slightly
-            let delay = Double(cardIndex) * 0.05
-            try? await Task.sleep(for: .seconds(delay))
-
-            // Animate to final position using settings duration (with collision validation)
-            moveCardSafely(
-                card,
-                to: Transform(scale: [1, 1, 1], rotation: cardRotation, translation: cardPosition),
-                duration: settings.inHandsAnimationDuration,
-                timingFunction: .easeInOut
-            )
-        }
-    }
+    // Delegate to shared fan logic
+    await fanCardsInHands()
 }
 
 internal func dealSingleCard(_ card: Entity, toSide sideIndex: Int, delay: Double, randomSpread: Float = 0.015) async {

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+InHands.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+InHands.swift
@@ -1,365 +1,269 @@
 import Foundation
 import RealityKit
 
+// MARK: - Side Geometry
+
+/// Describes the world-space geometry for a card fan on one side of the table.
+/// All positions and directions are in world coordinates, derived from TableGeometry.
+internal struct SideGeometry {
+    let fanCenter: SIMD3<Float>    // world position at table edge (pivot at bottom of cards)
+    let facing: SIMD3<Float>       // unit vector toward player
+    let spread: SIMD3<Float>       // unit vector along table edge (perpendicular to facing)
+    let baseYRotation: Float       // Y rotation so card face points toward player
+}
+
 extension CardPhysicsScene {
 
-// MARK: - Safe Movement Wrapper
+    /// Compute the side geometry for a given player side, using table constants.
+    /// The pivot point sits well above the rail tops and inward from the rail edges
+    /// so cards don't clip into the rail geometry.
+    internal func sideGeometry(for side: Int, tiltAngle: Float) -> SideGeometry {
+        // Rail tops are at ~0.0325m; lift the pivot well above for clearance
+        let pivotY: Float = 0.10
+        // Pull fan centers inward from the rail inner edges to prevent rail overlap
+        let inset: Float = 0.05
 
-/// Safely move a card to a target transform, validating against table collision
-private func moveCardSafely(
-    _ card: Entity,
-    to transform: Transform,
-    duration: TimeInterval = 0.3,
-    timingFunction: AnimationTimingFunction = .easeInOut,
-    curvature: Float = 0.0
-) {
-    let safeTransform = CollisionUtils.validateCardTransform(
-        transform,
-        cardWidth: CardEntity3D.cardWidth,
-        cardHeight: CardEntity3D.cardHeight,
-        cardDepth: CardEntity3D.cardDepth,
-        curvature: curvature,
-        scene: nil
-    )
-
-    card.move(to: safeTransform, relativeTo: nil, duration: duration, timingFunction: timingFunction)
-}
-
-/// Validate a position against table collision
-private func validateCardPosition(
-    _ position: SIMD3<Float>,
-    rotation: simd_quatf,
-    curvature: Float = 0.0
-) -> SIMD3<Float> {
-    let transform = Transform(rotation: rotation, translation: position)
-
-    let safeTransform = CollisionUtils.validateCardTransform(
-        transform,
-        cardWidth: CardEntity3D.cardWidth,
-        cardHeight: CardEntity3D.cardHeight,
-        cardDepth: CardEntity3D.cardDepth,
-        curvature: curvature,
-        scene: nil
-    )
-
-    return safeTransform.translation
-}
-
-/// Apply curvature to a card's mesh for the in-hand look
-private func applyCardCurvature(_ card: Entity, curvature: Float) {
-    guard let modelEntity = card as? ModelEntity,
-          var modelComponent = modelEntity.model else { return }
-    modelComponent.mesh = CurvedCardMesh.mesh(curvature: curvature)
-    modelEntity.model = modelComponent
-}
-
-// MARK: - Fan Cards
-
-public func fanCardsInHands() async {
-    guard !cards.isEmpty else { return }
-
-    // Group cards by their assigned side
-    var sideCards: [Int: [Entity]] = [:]
-    for card in cards {
-        let side = cardSideAssignments[ObjectIdentifier(card)] ?? 1
-        sideCards[side, default: []].append(card)
-    }
-
-    let cardHeight: Float = 0.15 // How much to lift cards off table
-
-    // Stack positions for each hand (at table edge, closer to player)
-    let stackPositions: [Int: SIMD3<Float>] = [
-        1: [0, cardHeight, 0.45],      // Bottom player (closest to viewer)
-        2: [-0.65, cardHeight, 0],     // Left player
-        3: [0, cardHeight, -0.45],     // Top player (farthest)
-        4: [0.65, cardHeight, 0]       // Right player
-    ]
-
-    for (side, cardsInSide) in sideCards {
-        guard let stackCenter = stackPositions[side] else { continue }
-
-        let cardCount = cardsInSide.count
-        guard cardCount > 0 else { continue }
-
-        for (index, card) in cardsInSide.enumerated() {
-            // Switch to kinematic for scripted animation
-            if var physicsBody = card.components[PhysicsBodyComponent.self] {
-                physicsBody.mode = .kinematic
-                card.components[PhysicsBodyComponent.self] = physicsBody
-            }
-            card.components[PhysicsMotionComponent.self] = nil
-
-            // STEP 1: Stack cards vertically (perpendicular to table)
-            // - Cards stand STRAIGHT UP (perpendicular to table, no tilt)
-            // - Face pointing outward toward player
-            // - Cards stacked with thickness offset (0.0015m per card)
-
-            // Base vertical orientation:
-            // Rotate 90° around X to stand card up (was lying flat, now vertical)
-            let standUpRotation = simd_quatf(angle: .pi / 2, axis: [1, 0, 0])
-
-            // Rotate around Y to face the player position
-            let faceOutwardRotation: simd_quatf
-            let stackDirection: SIMD3<Float> // Direction to offset cards in stack
-
-            switch side {
-            case 1: // Bottom player - face toward camera (+Z)
-                // After standing up, card faces -Z, so rotate 180° around Y to face +Z
-                faceOutwardRotation = simd_quatf(angle: .pi, axis: [0, 1, 0])
-                // Stack toward table center (backs point -Z)
-                stackDirection = [0, 0, -1]
-
-            case 2: // Left player - face toward left (-X)
-                // After standing up, rotate 90° around Y to face left
-                faceOutwardRotation = simd_quatf(angle: .pi / 2, axis: [0, 1, 0])
-                // Stack toward table center (backs point +X)
-                stackDirection = [1, 0, 0]
-
-            case 3: // Top player - face away from camera (-Z)
-                // After standing up, card already faces -Z, no additional rotation
-                faceOutwardRotation = simd_quatf(angle: 0, axis: [0, 1, 0])
-                // Stack toward camera (backs point +Z)
-                stackDirection = [0, 0, 1]
-
-            case 4: // Right player - face toward right (+X)
-                // After standing up, rotate -90° around Y to face right
-                faceOutwardRotation = simd_quatf(angle: -.pi / 2, axis: [0, 1, 0])
-                // Stack toward table center (backs point -X)
-                stackDirection = [-1, 0, 0]
-
-            default:
-                faceOutwardRotation = simd_quatf(angle: 0, axis: [0, 1, 0])
-                stackDirection = [0, 0, 0]
-            }
-
-            // Combine: first stand up, then rotate to face outward (NO TILT)
-            let stackedRotation = faceOutwardRotation * standUpRotation
-
-            // Stack position with thickness offset (0.0015m per card for visibility)
-            let cardThickness: Float = 0.0015
-            let stackOffset = stackDirection * (Float(index) * cardThickness)
-            let stackPosition = stackCenter + stackOffset
-
-            // Animate card to stacked vertical position (with collision validation)
-            moveCardSafely(
-                card,
-                to: Transform(
-                    scale: card.scale,
-                    rotation: stackedRotation,
-                    translation: stackPosition
-                ),
-                duration: 0.6,
-                timingFunction: .easeInOut
+        // baseYRotation: after standUp (-π/2 around X), the card face points +Z.
+        // Rotate around Y to aim the face toward the player on each side.
+        switch side {
+        case 1: // Bottom — face toward +Z (camera), no extra rotation
+            return SideGeometry(
+                fanCenter: SIMD3(0, pivotY, TableGeometry.innerMaxZ - inset),
+                facing: SIMD3(0, 0, 1),
+                spread: SIMD3(1, 0, 0),
+                baseYRotation: 0
+            )
+        case 2: // Left — face toward -X
+            return SideGeometry(
+                fanCenter: SIMD3(TableGeometry.innerMinX + inset, pivotY, 0),
+                facing: SIMD3(-1, 0, 0),
+                spread: SIMD3(0, 0, 1),
+                baseYRotation: -.pi / 2
+            )
+        case 3: // Top — face toward -Z
+            return SideGeometry(
+                fanCenter: SIMD3(0, pivotY, TableGeometry.innerMinZ + inset),
+                facing: SIMD3(0, 0, -1),
+                spread: SIMD3(-1, 0, 0),
+                baseYRotation: .pi
+            )
+        case 4: // Right — face toward +X
+            return SideGeometry(
+                fanCenter: SIMD3(TableGeometry.innerMaxX - inset, pivotY, 0),
+                facing: SIMD3(1, 0, 0),
+                spread: SIMD3(0, 0, -1),
+                baseYRotation: .pi / 2
+            )
+        default:
+            return SideGeometry(
+                fanCenter: SIMD3(0, pivotY, TableGeometry.innerMaxZ - inset),
+                facing: SIMD3(0, 0, 1),
+                spread: SIMD3(1, 0, 0),
+                baseYRotation: 0
             )
         }
     }
 
-    // Wait for stacking animation to complete
-    try? await Task.sleep(for: .seconds(0.6))
+    // MARK: - Physics Helpers
 
-    // STEP 2: Apply curvature and fan out from stacked position
-    for card in cards {
-        let side = cardSideAssignments[ObjectIdentifier(card)] ?? 1
-        let sideSettings = settings.inHandsSettings(for: side)
-        if sideSettings.curvature != 0 {
-            applyCardCurvature(card, curvature: sideSettings.curvature)
+    /// Remove physics components from a card. Cards in the fan are positioned
+    /// directly and don't need physics simulation.
+    internal func stripPhysics(from card: Entity) {
+        card.components.remove(PhysicsBodyComponent.self)
+        card.components.remove(CollisionComponent.self)
+        card.components.remove(PhysicsMotionComponent.self)
+    }
+
+    /// Restore physics components to a card (for returning to table).
+    internal func restorePhysics(to card: Entity, mode: PhysicsBodyMode = .kinematic) {
+        let shape = ShapeResource.generateBox(
+            width: CardEntity3D.cardWidth,
+            height: CardEntity3D.cardHeight,
+            depth: CardEntity3D.cardDepth
+        )
+        card.components.set(CollisionComponent(shapes: [shape]))
+
+        var physicsBody = PhysicsBodyComponent(
+            massProperties: .default,
+            material: .generate(
+                staticFriction: 0.25,
+                dynamicFriction: 0.2,
+                restitution: 0.05
+            ),
+            mode: mode
+        )
+        physicsBody.isContinuousCollisionDetectionEnabled = true
+        physicsBody.linearDamping = 0.1
+        physicsBody.angularDamping = 0.3
+        card.components.set(physicsBody)
+    }
+
+    /// Apply curvature to a card's mesh. Only updates the collision shape if the card
+    /// has a physics body (cards in the fan have physics stripped).
+    internal func applyCardCurvature(_ card: Entity, curvature: Float) {
+        guard let modelEntity = card as? ModelEntity,
+              var modelComponent = modelEntity.model else { return }
+        modelComponent.mesh = CurvedCardMesh.mesh(curvature: curvature)
+        modelEntity.model = modelComponent
+
+        // Only update collision shape if the card has physics (not in fan state)
+        if modelEntity.components[PhysicsBodyComponent.self] != nil {
+            let collisionHeight = CardEntity3D.cardHeight + (abs(curvature) * 2.0)
+            let shape = ShapeResource.generateBox(
+                width: CardEntity3D.cardWidth,
+                height: collisionHeight,
+                depth: CardEntity3D.cardDepth
+            )
+            modelEntity.components.set(CollisionComponent(shapes: [shape]))
         }
     }
 
-    // Update positions to fan out with curvature applied
-    updateInHandsCardPositions()
-}
+    // MARK: - Fan Cards
 
-/// Flips a card 180 degrees around the X axis with a short animation.
-/// Only flips cards that are in dynamic or kinematic mode (not during active move animations).
-internal func flipCard(_ card: Entity) {
-    guard let physicsBody = card.components[PhysicsBodyComponent.self],
-          physicsBody.mode == .dynamic || physicsBody.mode == .kinematic else {
-        return
+    public func fanCardsInHands() async {
+        guard !cards.isEmpty else { return }
+
+        // Strip physics from all cards — they stay as direct children of rootEntity
+        for card in cards {
+            stripPhysics(from: card)
+            // Flatten any existing curvature — cards are flat in the fan
+            applyCardCurvature(card, curvature: 0)
+        }
+
+        cardsInFanState = true
+        updateInHandsCardPositions()
     }
 
-    // Increment wear on flip interaction
-    incrementCardWear(card)
+    /// Flips a card 180 degrees with a short animation.
+    /// Works both in fan state (no physics) and on table (with physics).
+    internal func flipCard(_ card: Entity) {
+        let hasPhysics = card.components[PhysicsBodyComponent.self] != nil
 
-    // Determine current face orientation: face-up has ~pi rotation around X
-    let currentRotation = card.orientation
-    // Check if the card's local Y axis is pointing down (face-up) or up (face-down)
-    let localUp = currentRotation.act(SIMD3<Float>(0, 1, 0))
-    let isFaceUp = localUp.y < 0
+        guard hasPhysics || cardsInFanState else { return }
 
-    // Target orientation: toggle between face-up (pi around X) and face-down (identity)
-    let targetOrientation = isFaceUp
-        ? simd_quatf(angle: 0, axis: [1, 0, 0])  // face-down (identity)
-        : simd_quatf(angle: .pi, axis: [1, 0, 0]) // face-up
+        // Increment wear on flip interaction
+        incrementCardWear(card)
 
-    // Temporarily switch to kinematic for the flip animation
-    let previousMode = physicsBody.mode
-    if previousMode == .dynamic {
-        var body = physicsBody
-        body.mode = .kinematic
-        card.components[PhysicsBodyComponent.self] = body
-        card.components[PhysicsMotionComponent.self] = nil
-    }
+        if cardsInFanState {
+            // In fan: flip around the card's local width axis (world-space animation)
+            let currentOrientation = card.orientation
+            let flipRotation = simd_quatf(angle: .pi, axis: currentOrientation.act(SIMD3<Float>(1, 0, 0)))
+            let targetOrientation = flipRotation * currentOrientation
 
-    moveCardSafely(
-        card,
-        to: Transform(
-            scale: card.scale,
-            rotation: targetOrientation,
-            translation: card.position
-        ),
-        duration: 0.25,
-        timingFunction: .easeInOut
-    )
+            card.move(
+                to: Transform(
+                    scale: card.scale,
+                    rotation: targetOrientation,
+                    translation: card.position
+                ),
+                relativeTo: nil,
+                duration: 0.25,
+                timingFunction: .easeInOut
+            )
+        } else {
+            // On table: existing behavior
+            let currentRotation = card.orientation
+            let localUp = currentRotation.act(SIMD3<Float>(0, 1, 0))
+            let isFaceUp = localUp.y < 0
 
-    // Restore dynamic mode after flip completes
-    if previousMode == .dynamic {
-        Task {
-            try? await Task.sleep(for: .seconds(0.25))
-            if var body = card.components[PhysicsBodyComponent.self] {
-                body.mode = .dynamic
+            let targetOrientation = isFaceUp
+                ? simd_quatf(angle: 0, axis: [1, 0, 0])
+                : simd_quatf(angle: .pi, axis: [1, 0, 0])
+
+            let previousMode = card.components[PhysicsBodyComponent.self]?.mode ?? .kinematic
+            if previousMode == .dynamic {
+                var body = card.components[PhysicsBodyComponent.self]!
+                body.mode = .kinematic
                 card.components[PhysicsBodyComponent.self] = body
+                card.components[PhysicsMotionComponent.self] = nil
+            }
+
+            moveCardSafely(
+                card,
+                to: Transform(
+                    scale: card.scale,
+                    rotation: targetOrientation,
+                    translation: card.position
+                ),
+                duration: 0.25,
+                timingFunction: .easeInOut
+            )
+
+            if previousMode == .dynamic {
+                Task {
+                    try? await Task.sleep(for: .seconds(0.25))
+                    if var body = card.components[PhysicsBodyComponent.self] {
+                        body.mode = .dynamic
+                        card.components[PhysicsBodyComponent.self] = body
+                    }
+                }
             }
         }
     }
-}
 
-/// Updates the positions of cards already in hands based on current settings
-/// without re-dealing them. Used for real-time slider adjustments.
-internal func updateInHandsCardPositions() {
-    guard !cards.isEmpty else { return }
+    /// Updates card positions using fan-from-bottom world-space math.
+    /// Cards are stacked together above the table and fanned out from a pivot
+    /// at the bottom of the stack, like holding cards in a real hand.
+    /// Called on every slider change for real-time feedback.
+    internal func updateInHandsCardPositions() {
+        guard !cards.isEmpty, cardsInFanState else { return }
 
-    // Group cards by their assigned side
-    var sideCards: [Int: [Entity]] = [:]
-    for card in cards {
-        let side = cardSideAssignments[ObjectIdentifier(card)] ?? 1
-        sideCards[side, default: []].append(card)
-    }
+        // Group cards by their assigned side
+        var sideCards: [Int: [Entity]] = [:]
+        for card in cards {
+            let side = cardSideAssignments[ObjectIdentifier(card)] ?? 1
+            sideCards[side, default: []].append(card)
+        }
 
-    // Update positions for each side
-    for side in 1...4 {
-        guard let cardsInSide = sideCards[side], !cardsInSide.isEmpty else { continue }
+        // Half the card's standing height — distance from bottom pivot to card center
+        let fanRadius = CardEntity3D.cardDepth / 2  // 0.088m
 
-        let fanCenter = HandEntity3D.getFanCenterPosition(side: side)
-        let sideSettings = settings.inHandsSettings(for: side)
+        for side in 1...4 {
+            guard let cardsInSide = sideCards[side], !cardsInSide.isEmpty else { continue }
 
-        for (cardIndex, card) in cardsInSide.enumerated() {
-            // Calculate fan arc parameters from per-side settings
-            let fanAngle = sideSettings.fanAngle
-            let verticalOffset = sideSettings.verticalSpacing
-            let arcRadius = sideSettings.arcRadius
+            let sideSettings = settings.inHandsSettings(for: side)
+            let geo = sideGeometry(for: side, tiltAngle: sideSettings.tiltAngle)
 
-            // Fan from bottom of deck: first card at center, others spread outward
-            // Cards fan symmetrically around center (middle card straight)
-            let normalizedIndex = Float(cardIndex) / Float(max(cardsInSide.count - 1, 1))
-            let fanProgress = normalizedIndex - 0.5  // -0.5 to 0.5 (centered)
-            let arcAngle = fanProgress * fanAngle
+            let cardCount = cardsInSide.count
 
-            // Base vertical orientation (same as fanCardsInHands):
-            // 1. Stand card up perpendicular to table
-            let standUpRotation = simd_quatf(angle: .pi / 2, axis: [1, 0, 0])
+            for (index, card) in cardsInSide.enumerated() {
+                // Fan progress: -0.5 to +0.5
+                let t = cardCount > 1
+                    ? (Float(index) / Float(cardCount - 1)) - 0.5
+                    : 0.0
+                let arcAngle = t * sideSettings.fanAngle
 
-            // 2. Rotate to face player position
-            let faceOutwardRotation: simd_quatf
-            let stackDirection: SIMD3<Float>
+                // Fan rotation around facing direction, pivoting at bottom of card stack
+                let fanRotation = simd_quatf(angle: arcAngle, axis: geo.facing)
 
-            switch side {
-            case 1: // Bottom player - face toward camera (+Z)
-                faceOutwardRotation = simd_quatf(angle: .pi, axis: [0, 1, 0])
-                stackDirection = [0, 0, -1]
+                // Card center offset from pivot (straight up before fan rotation)
+                let centerOffset = SIMD3<Float>(0, fanRadius, 0)
 
-            case 2: // Left player - face toward left (-X)
-                faceOutwardRotation = simd_quatf(angle: .pi / 2, axis: [0, 1, 0])
-                stackDirection = [1, 0, 0]
+                // Apply fan rotation to the offset (rotates card around bottom pivot)
+                let fannedOffset = fanRotation.act(centerOffset)
 
-            case 3: // Top player - face away from camera (-Z)
-                faceOutwardRotation = simd_quatf(angle: 0, axis: [0, 1, 0])
-                stackDirection = [0, 0, 1]
+                // Apply tilt (lean cards back to show faces to overhead camera)
+                let tiltRotation = simd_quatf(angle: sideSettings.tiltAngle, axis: geo.spread)
+                let tiltedOffset = tiltRotation.act(fannedOffset)
 
-            case 4: // Right player - face toward right (+X)
-                faceOutwardRotation = simd_quatf(angle: -.pi / 2, axis: [0, 1, 0])
-                stackDirection = [-1, 0, 0]
+                // Depth ordering: tiny offset along facing to prevent z-fighting
+                let depthOrder = Float(index) * CardEntity3D.cardHeight * geo.facing
 
-            default:
-                faceOutwardRotation = simd_quatf(angle: 0, axis: [0, 1, 0])
-                stackDirection = [0, 0, 0]
+                let cardPosition = geo.fanCenter + tiltedOffset + depthOrder
+
+                // Card orientation composed from clear, independent rotations:
+                // 1. Stand card up (-π/2 around X): face points +Z, card stands vertical
+                let standUp = simd_quatf(angle: -.pi / 2, axis: SIMD3<Float>(1, 0, 0))
+                // 2. Face toward player (Y rotation for this side)
+                let facePlayer = simd_quatf(angle: geo.baseYRotation, axis: SIMD3<Float>(0, 1, 0))
+                // 3. Fan spread (rotate around facing axis, same as position fan)
+                // 4. Tilt back (lean toward player to show faces from overhead)
+                let orientation = tiltRotation * fanRotation * facePlayer * standUp
+
+                card.position = cardPosition
+                card.orientation = orientation
             }
-
-            // 3. Apply slider adjustments from vertical base
-            let tiltQuat = simd_quatf(angle: sideSettings.tiltAngle, axis: [1, 0, 0])
-            let fanQuat = simd_quatf(angle: arcAngle, axis: [0, 1, 0])
-            let offsetQuat = simd_quatf(angle: sideSettings.rotationOffset, axis: [0, 1, 0])
-
-            // Combine rotations: face outward, then fan, then tilt, then rotation offset, then stand up
-            let cardRotation = offsetQuat * fanQuat * tiltQuat * faceOutwardRotation * standUpRotation
-
-            // Calculate position: pivot from bottom center of deck
-            // Bottom center is at fanCenter - cards fan out from there
-            let cardThickness: Float = 0.0015
-
-            // Start at pivot point (bottom center of deck)
-            let pivotPoint = fanCenter
-
-            // Calculate offset from pivot based on fan angle and arc radius
-            // Each card rotates around the pivot and moves outward along the arc
-            var cardPosition: SIMD3<Float>
-
-            switch side {
-            case 1: // Bottom - fan spreads left/right (+/-X), arc extends toward player (+Z)
-                let fanX = sin(arcAngle) * arcRadius
-                let fanZ = (1.0 - cos(arcAngle)) * arcRadius  // Arc toward player
-                cardPosition = SIMD3(
-                    pivotPoint.x + fanX,
-                    pivotPoint.y + Float(cardIndex) * verticalOffset,
-                    pivotPoint.z + fanZ
-                )
-                // Stack offset perpendicular to face
-                cardPosition += stackDirection * (Float(cardIndex) * cardThickness)
-
-            case 2: // Left - fan spreads up/down (+/-Z), arc extends toward player (-X)
-                let fanZ = sin(arcAngle) * arcRadius
-                let fanX = -(1.0 - cos(arcAngle)) * arcRadius  // Arc toward player (left)
-                cardPosition = SIMD3(
-                    pivotPoint.x + fanX,
-                    pivotPoint.y + Float(cardIndex) * verticalOffset,
-                    pivotPoint.z + fanZ
-                )
-                cardPosition += stackDirection * (Float(cardIndex) * cardThickness)
-
-            case 3: // Top - fan spreads left/right (+/-X), arc extends toward player (-Z)
-                let fanX = sin(arcAngle) * arcRadius
-                let fanZ = -(1.0 - cos(arcAngle)) * arcRadius  // Arc toward player (away)
-                cardPosition = SIMD3(
-                    pivotPoint.x - fanX,  // Mirror X for top player
-                    pivotPoint.y + Float(cardIndex) * verticalOffset,
-                    pivotPoint.z + fanZ
-                )
-                cardPosition += stackDirection * (Float(cardIndex) * cardThickness)
-
-            case 4: // Right - fan spreads up/down (+/-Z), arc extends toward player (+X)
-                let fanZ = sin(arcAngle) * arcRadius
-                let fanX = (1.0 - cos(arcAngle)) * arcRadius  // Arc toward player (right)
-                cardPosition = SIMD3(
-                    pivotPoint.x + fanX,
-                    pivotPoint.y + Float(cardIndex) * verticalOffset,
-                    pivotPoint.z - fanZ  // Mirror Z for right player
-                )
-                cardPosition += stackDirection * (Float(cardIndex) * cardThickness)
-
-            default:
-                cardPosition = pivotPoint
-            }
-
-            // Apply curvature to card mesh
-            applyCardCurvature(card, curvature: sideSettings.curvature)
-
-            // Update card transform instantly (no animation for real-time feedback)
-            // Validate position to prevent table penetration
-            let safePosition = validateCardPosition(cardPosition, rotation: cardRotation, curvature: sideSettings.curvature)
-            card.position = safePosition
-            card.orientation = cardRotation
         }
     }
-}
 
 }

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+PickUp.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+PickUp.swift
@@ -3,33 +3,19 @@ import RealityKit
 
 extension CardPhysicsScene {
 
-// MARK: - Safe Movement Wrapper
-
-/// Safely move a card to a target transform, validating against table collision
-private func moveCardSafely(
-    _ card: Entity,
-    to transform: Transform,
-    duration: TimeInterval = 0.3,
-    timingFunction: AnimationTimingFunction = .easeInOut
-) {
-    let curvature: Float = 0.0  // Cards in pickup are flat
-
-    let safeTransform = CollisionUtils.validateCardTransform(
-        transform,
-        cardWidth: CardEntity3D.cardWidth,
-        cardHeight: CardEntity3D.cardHeight,
-        cardDepth: CardEntity3D.cardDepth,
-        curvature: curvature,
-        scene: nil
-    )
-
-    card.move(to: safeTransform, relativeTo: nil, duration: duration, timingFunction: timingFunction)
-}
-
 // MARK: - Gather and Pick Up
 
 public func gatherAndPickUp(corner: GatherCorner) async {
     guard !cards.isEmpty else { return }
+
+    // If cards are in fan state, restore physics and flatten curvature
+    if cardsInFanState {
+        for card in cards {
+            restorePhysics(to: card, mode: .kinematic)
+            applyCardCurvature(card, curvature: 0)
+        }
+        cardsInFanState = false
+    }
 
     // Calculate corner position based on table dimensions
     // tableWidth=1.4, tableDepth=1.0, rail=0.07

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+SafeMovement.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Animations/CardPhysicsScene+SafeMovement.swift
@@ -1,0 +1,49 @@
+import Foundation
+import RealityKit
+
+extension CardPhysicsScene {
+
+    /// Safely move a card to a target transform, validating against table collision.
+    /// Shared by all animation files (Dealing, InHands, PickUp).
+    internal func moveCardSafely(
+        _ card: Entity,
+        to transform: Transform,
+        duration: TimeInterval = 0.3,
+        timingFunction: AnimationTimingFunction = .easeInOut,
+        curvature: Float = 0.0,
+        clampToBounds: Bool = false
+    ) {
+        let safeTransform = CollisionUtils.validateCardTransform(
+            transform,
+            cardWidth: CardEntity3D.cardWidth,
+            cardHeight: CardEntity3D.cardHeight,
+            cardDepth: CardEntity3D.cardDepth,
+            curvature: curvature,
+            clampToBounds: clampToBounds
+        )
+
+        card.move(to: safeTransform, relativeTo: nil, duration: duration, timingFunction: timingFunction)
+    }
+
+    /// Validate a position against table collision, returning a corrected position.
+    /// Used for real-time slider updates where position is set directly (no animation).
+    internal func validateCardPosition(
+        _ position: SIMD3<Float>,
+        rotation: simd_quatf,
+        curvature: Float = 0.0,
+        clampToBounds: Bool = false
+    ) -> SIMD3<Float> {
+        let transform = Transform(rotation: rotation, translation: position)
+
+        let safeTransform = CollisionUtils.validateCardTransform(
+            transform,
+            cardWidth: CardEntity3D.cardWidth,
+            cardHeight: CardEntity3D.cardHeight,
+            cardDepth: CardEntity3D.cardDepth,
+            curvature: curvature,
+            clampToBounds: clampToBounds
+        )
+
+        return safeTransform.translation
+    }
+}

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Core/CollisionUtils.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Core/CollisionUtils.swift
@@ -1,135 +1,160 @@
 import RealityKit
 
+// MARK: - Table Geometry Constants
+
+@MainActor
+enum TableGeometry {
+    static let tableWidth: Float = 1.4
+    static let tableDepth: Float = 1.0
+    static let railThickness: Float = 0.07
+    static let railHeight: Float = 0.035
+
+    /// Top of the felt box (5mm box centered at Y=0.0025)
+    static let feltSurfaceY: Float = 0.005
+
+    /// Inner playable area (inside rail inner edges)
+    static let innerMinX: Float = -(tableWidth / 2 - railThickness)   // -0.63
+    static let innerMaxX: Float = tableWidth / 2 - railThickness      //  0.63
+    static let innerMinZ: Float = -(tableDepth / 2 - railThickness)   // -0.43
+    static let innerMaxZ: Float = tableDepth / 2 - railThickness      //  0.43
+}
+
+// MARK: - Collision Utilities
+
 @MainActor
 enum CollisionUtils {
-    /// Calculate minimum safe Y position for a card accounting for rotation and curvature
-    /// - Parameters:
-    ///   - rotation: Card's rotation quaternion
-    ///   - curvature: Card's parabolic curvature value (meters)
-    ///   - cardHeight: Card thickness (meters)
-    /// - Returns: Minimum Y position to keep card above origin plane
-    static func minimumCardY(
-        rotation: simd_quatf,
-        curvature: Float,
-        cardHeight: Float
-    ) -> Float {
-        // Base clearance is half the card thickness
-        var minY = cardHeight / 2.0
 
-        // Add curvature displacement (maximum bow height)
-        if curvature != 0 {
-            minY += abs(curvature)
-        }
+    /// Compute the 4 card corners in world space after applying rotation.
+    /// Corners are at the card's mid-plane (Y=0 in local space).
+    static func cardCornerPositions(
+        transform: Transform,
+        cardWidth: Float,
+        cardDepth: Float
+    ) -> (SIMD3<Float>, SIMD3<Float>, SIMD3<Float>, SIMD3<Float>) {
+        let halfW = cardWidth / 2
+        let halfD = cardDepth / 2
 
-        // Account for rotation: if card is tilted, need more clearance
-        // Extract rotation around X and Z axes
-        let rotationMatrix = simd_float3x3(rotation)
-        let upVector = rotationMatrix.columns.1  // Y-axis after rotation
+        let rotation = transform.rotation
+        let t = transform.translation
 
-        // If card is tilted (Y component < 1), add clearance
-        // proportional to the tilt angle
-        let tiltFactor = abs(1.0 - upVector.y)
-        if tiltFactor > 0.01 {
-            // Add extra clearance based on card dimensions and tilt
-            let maxDimension = max(CardEntity3D.cardWidth, CardEntity3D.cardDepth)
-            minY += maxDimension * tiltFactor * 0.5
-        }
+        let c0 = rotation.act(SIMD3(-halfW, 0, -halfD)) + t
+        let c1 = rotation.act(SIMD3( halfW, 0, -halfD)) + t
+        let c2 = rotation.act(SIMD3(-halfW, 0,  halfD)) + t
+        let c3 = rotation.act(SIMD3( halfW, 0,  halfD)) + t
 
-        return minY
+        return (c0, c1, c2, c3)
     }
 
-    /// Validate transform against table collision, return corrected transform if needed
+    /// Calculate how much to raise a card so that no corner or the curved center
+    /// penetrates the felt surface.
+    /// - Returns: The Y offset to add (0 if no raise needed)
+    static func minimumYRaise(
+        transform: Transform,
+        cardWidth: Float,
+        cardHeight: Float,
+        cardDepth: Float,
+        curvature: Float
+    ) -> Float {
+        let (c0, c1, c2, c3) = cardCornerPositions(
+            transform: transform,
+            cardWidth: cardWidth,
+            cardDepth: cardDepth
+        )
+
+        let halfThickness = cardHeight / 2
+
+        // Lowest corner Y, offset by half card thickness below the mid-plane
+        let lowestCornerY = min(min(c0.y, c1.y), min(c2.y, c3.y)) - halfThickness
+
+        // Curvature pushes the center of the card downward (in local space)
+        // by abs(curvature). Transform that point to world space.
+        var lowestY = lowestCornerY
+        if curvature != 0 {
+            let centerBottom = transform.rotation.act(
+                SIMD3(0, -halfThickness - abs(curvature), 0)
+            ) + transform.translation
+            lowestY = min(lowestY, centerBottom.y)
+        }
+
+        let gap = TableGeometry.feltSurfaceY - lowestY
+        return gap > 0 ? gap : 0
+    }
+
+    /// Shift the card center so no corner extends past the inner rail edges.
+    /// - Returns: Corrected translation
+    static func clampToBoundaries(
+        transform: Transform,
+        cardWidth: Float,
+        cardDepth: Float
+    ) -> SIMD3<Float> {
+        let (c0, c1, c2, c3) = cardCornerPositions(
+            transform: transform,
+            cardWidth: cardWidth,
+            cardDepth: cardDepth
+        )
+
+        var translation = transform.translation
+
+        let minCX = min(min(c0.x, c1.x), min(c2.x, c3.x))
+        let maxCX = max(max(c0.x, c1.x), max(c2.x, c3.x))
+        let minCZ = min(min(c0.z, c1.z), min(c2.z, c3.z))
+        let maxCZ = max(max(c0.z, c1.z), max(c2.z, c3.z))
+
+        if minCX < TableGeometry.innerMinX {
+            translation.x += (TableGeometry.innerMinX - minCX)
+        } else if maxCX > TableGeometry.innerMaxX {
+            translation.x -= (maxCX - TableGeometry.innerMaxX)
+        }
+
+        if minCZ < TableGeometry.innerMinZ {
+            translation.z += (TableGeometry.innerMinZ - minCZ)
+        } else if maxCZ > TableGeometry.innerMaxZ {
+            translation.z -= (maxCZ - TableGeometry.innerMaxZ)
+        }
+
+        return translation
+    }
+
+    /// Validate a card transform against table collision, returning a corrected transform.
     /// - Parameters:
     ///   - transform: Desired card transform
     ///   - cardWidth: Card width in meters
     ///   - cardHeight: Card thickness in meters
     ///   - cardDepth: Card depth in meters
-    ///   - curvature: Card curvature value
-    ///   - scene: RealityKit scene for ray casting (optional, for future enhancement)
-    /// - Returns: Validated transform that won't penetrate the table
+    ///   - curvature: Card curvature value (meters of parabolic bow)
+    ///   - clampToBounds: Whether to clamp X/Z within rail boundaries
+    /// - Returns: Validated transform that won't penetrate the table or rails
     static func validateCardTransform(
         _ transform: Transform,
         cardWidth: Float,
         cardHeight: Float,
         cardDepth: Float,
         curvature: Float,
-        scene: Scene? = nil
+        clampToBounds: Bool = false
     ) -> Transform {
-        var validatedTransform = transform
+        var result = transform
 
-        // Calculate minimum safe Y position
-        let minY = minimumCardY(
-            rotation: transform.rotation,
-            curvature: curvature,
-            cardHeight: cardHeight
+        // Raise Y if any corner/center would penetrate the felt surface
+        let raise = minimumYRaise(
+            transform: result,
+            cardWidth: cardWidth,
+            cardHeight: cardHeight,
+            cardDepth: cardDepth,
+            curvature: curvature
         )
-
-        // Table surface is at Y=0, ensure card stays above it
-        let tableY: Float = 0.0
-        let requiredY = tableY + minY
-
-        // If card would penetrate table, raise it to safe height
-        if validatedTransform.translation.y < requiredY {
-            validatedTransform.translation.y = requiredY
+        if raise > 0 {
+            result.translation.y += raise
         }
 
-        return validatedTransform
-    }
+        // Optionally clamp X/Z to keep within rails
+        if clampToBounds {
+            result.translation = clampToBoundaries(
+                transform: result,
+                cardWidth: cardWidth,
+                cardDepth: cardDepth
+            )
+        }
 
-    /// Find table surface height below a given position using ray casting
-    /// - Parameters:
-    ///   - position: Position to cast ray from
-    ///   - scene: RealityKit scene to query
-    /// - Returns: Y coordinate of table surface, or nil if not found
-    static func findTableSurfaceBelow(
-        position: SIMD3<Float>,
-        scene: Scene
-    ) -> Float? {
-        // Ray cast downward from position
-        let rayOrigin = position
-        let rayDirection = SIMD3<Float>(0, -1, 0)  // Downward
-
-        // Perform ray cast query
-        // Note: RealityKit's scene.raycast is available but requires proper collision layers
-        // For now, we'll use a fixed table height assumption
-        // This can be enhanced with actual raycasting when needed
-
-        // Table surface is at Y=0 in our scene
-        return 0.0
-    }
-
-    /// Validate that a card's position doesn't penetrate table rails or boundaries
-    /// - Parameters:
-    ///   - position: Card position to validate
-    ///   - tableWidth: Table width (X dimension)
-    ///   - tableDepth: Table depth (Z dimension)
-    ///   - railHeight: Height of table rails
-    ///   - cardRadius: Approximate card radius for boundary checking
-    /// - Returns: Corrected position if needed
-    static func validateTableBoundaries(
-        position: SIMD3<Float>,
-        tableWidth: Float,
-        tableDepth: Float,
-        railHeight: Float,
-        cardRadius: Float
-    ) -> SIMD3<Float> {
-        var validatedPosition = position
-
-        // Keep cards within table boundaries (with some margin)
-        let halfWidth = tableWidth / 2.0 - cardRadius
-        let halfDepth = tableDepth / 2.0 - cardRadius
-
-        // Clamp X position
-        validatedPosition.x = max(-halfWidth, min(halfWidth, validatedPosition.x))
-
-        // Clamp Z position
-        validatedPosition.z = max(-halfDepth, min(halfDepth, validatedPosition.z))
-
-        // Ensure card stays above table surface and below reasonable height
-        let minY: Float = 0.001  // Just above table
-        let maxY: Float = 0.5    // Reasonable max height
-        validatedPosition.y = max(minY, min(maxY, validatedPosition.y))
-
-        return validatedPosition
+        return result
     }
 }

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Entities/CardEntity3D.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Entities/CardEntity3D.swift
@@ -29,7 +29,6 @@ enum CardEntity3D {
             material.specular = .init(floatLiteral: 0.4)
             material.clearcoat = .init(floatLiteral: 0.8)
             material.clearcoatRoughness = .init(floatLiteral: 0.1)
-            material.opacityThreshold = 0.5
             return material
         }
 

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Entities/HandEntity3D.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Entities/HandEntity3D.swift
@@ -105,28 +105,31 @@ internal enum HandEntity3D {
         return handRoot
     }
 
-    /// Calculate the fan arc center position for a given side
+    /// Calculate the fan arc center position for a given side.
+    /// Positions are derived from TableGeometry constants so they stay in sync
+    /// with the actual table dimensions.
     /// - Parameter side: The player side (1-4)
     /// - Returns: Center position of the card fan arc
-    static func getFanCenterPosition(side: Int) -> SIMD3<Float> {
+    @MainActor static func getFanCenterPosition(side: Int) -> SIMD3<Float> {
+        let y: Float = 0.05 // Base Y — updateInHandsCardPositions computes dynamic Y
         switch side {
         case 1: // Bottom
-            return SIMD3(0, 0.05, 0.38)
+            return SIMD3(0, y, TableGeometry.innerMaxZ)
         case 2: // Left
-            return SIMD3(-0.58, 0.05, 0)
+            return SIMD3(TableGeometry.innerMinX, y, 0)
         case 3: // Top
-            return SIMD3(0, 0.05, -0.38)
+            return SIMD3(0, y, TableGeometry.innerMinZ)
         case 4: // Right
-            return SIMD3(0.58, 0.05, 0)
+            return SIMD3(TableGeometry.innerMaxX, y, 0)
         default:
-            return SIMD3(0, 0.05, 0)
+            return SIMD3(0, y, 0)
         }
     }
 
     /// Calculate hand position below the fan center
     /// - Parameter side: The player side (1-4)
     /// - Returns: Position for the hand entity
-    static func getHandPosition(side: Int) -> SIMD3<Float> {
+    @MainActor static func getHandPosition(side: Int) -> SIMD3<Float> {
         let fanCenter = getFanCenterPosition(side: side)
         // Position hand slightly below and closer to table
         switch side {

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Rendering/CardTextureGenerator.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Rendering/CardTextureGenerator.swift
@@ -40,8 +40,7 @@ final class CardTextureGenerator {
             // Render the rank/suit overlay (transparent background with corner indices)
             let overlayImage = renderCardFace(card, style: faceStyle)
             // Composite: photo underneath, overlay on top
-            let composited = compositeOverlay(overlayImage, over: photoImage) ?? photoImage
-            let finalImage = applyRoundedCornerMask(to: composited) ?? composited
+            let finalImage = compositeOverlay(overlayImage, over: photoImage) ?? photoImage
             let texture = try? TextureResource(
                 image: finalImage,
                 options: .init(semantic: .color)
@@ -63,8 +62,7 @@ final class CardTextureGenerator {
 
         guard let cgImage = renderCardFace(card, style: style) else { return nil }
 
-        let grainedImage = compositePaperGrain(over: cgImage) ?? cgImage
-        let finalImage = applyRoundedCornerMask(to: grainedImage) ?? grainedImage
+        let finalImage = compositePaperGrain(over: cgImage) ?? cgImage
 
         let texture = try? TextureResource(
             image: finalImage,
@@ -86,10 +84,9 @@ final class CardTextureGenerator {
             if let cached = cache[key] {
                 return cached
             }
-            guard let filename, let cgImage = loadAndCropCustomImage(filename: filename) else {
+            guard let filename, let finalImage = loadAndCropCustomImage(filename: filename) else {
                 return renderStyledBackTexture(style: .classicMaroon)
             }
-            let finalImage = applyRoundedCornerMask(to: cgImage) ?? cgImage
             let texture = try? TextureResource(
                 image: finalImage,
                 options: .init(semantic: .color)
@@ -109,8 +106,7 @@ final class CardTextureGenerator {
             return cached
         }
 
-        guard let rawImage = renderCardBack(style: style) else { return nil }
-        let cgImage = applyRoundedCornerMask(to: rawImage) ?? rawImage
+        guard let cgImage = renderCardBack(style: style) else { return nil }
 
         let texture = try? TextureResource(
             image: cgImage,
@@ -141,8 +137,7 @@ final class CardTextureGenerator {
             return texture(for: card)
         }
 
-        let wornImage = compositeOverlay(wearOverlay, over: grainedImage) ?? grainedImage
-        let finalImage = applyRoundedCornerMask(to: wornImage) ?? wornImage
+        let finalImage = compositeOverlay(wearOverlay, over: grainedImage) ?? grainedImage
 
         let texture = try? TextureResource(
             image: finalImage,
@@ -165,6 +160,7 @@ final class CardTextureGenerator {
     private func renderCardFace(_ card: Card, style: CardFaceStyle) -> CGImage? {
         let view = CardView(card: card, isFaceUp: true, size: .large, faceStyle: style)
             .frame(width: renderWidth, height: renderHeight)
+            .background(Color.white)
         let renderer = ImageRenderer(content: view)
         renderer.scale = 5.0
         return renderer.cgImage
@@ -174,6 +170,7 @@ final class CardTextureGenerator {
         let dummyCard = Card(suit: .spades, rank: .ace)
         let view = CardView(card: dummyCard, isFaceUp: false, size: .large, backStyle: style)
             .frame(width: renderWidth, height: renderHeight)
+            .background(Color.white)
         let renderer = ImageRenderer(content: view)
         renderer.scale = 5.0
         return renderer.cgImage
@@ -232,31 +229,6 @@ final class CardTextureGenerator {
     }
 
     // MARK: - Image Processing
-
-    private func applyRoundedCornerMask(to image: CGImage) -> CGImage? {
-        let w = image.width
-        let h = image.height
-
-        guard let ctx = CGContext(
-            data: nil,
-            width: w,
-            height: h,
-            bitsPerComponent: 8,
-            bytesPerRow: w * 4,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return nil }
-
-        let rect = CGRect(x: 0, y: 0, width: w, height: h)
-        let cornerRadius: CGFloat = 50.0
-        let path = CGPath(roundedRect: rect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil)
-
-        ctx.addPath(path)
-        ctx.clip()
-        ctx.draw(image, in: rect)
-
-        return ctx.makeImage()
-    }
 
     /// Composites a transparent overlay (rank/suit indicators) on top of a base image (custom photo)
     private func compositeOverlay(_ overlay: CGImage?, over baseImage: CGImage) -> CGImage? {

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Scene/CardPhysicsScene+Setup.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Scene/CardPhysicsScene+Setup.swift
@@ -22,8 +22,8 @@ internal func createTable() {
 
     // --- 1. The Main Wood Board (Base) ---
     // Rectangular table (wider than deep) matching Euchre render
-    let tableWidth: Float = 1.4
-    let tableDepth: Float = 1.0
+    let tableWidth = TableGeometry.tableWidth
+    let tableDepth = TableGeometry.tableDepth
 
     let baseMesh = MeshResource.generateBox(
         width: tableWidth,
@@ -71,8 +71,8 @@ internal func createTable() {
     // --- 2. The Raised Lip/Frame (Edge) ---
     // Thicker rails for a more substantial furniture look
 
-    let railThickness: Float = 0.07
-    let railHeight: Float = 0.035
+    let railThickness = TableGeometry.railThickness
+    let railHeight = TableGeometry.railHeight
 
     // Top/Bottom Rails with collision
     let hRailMesh = MeshResource.generateBox(width: tableWidth, height: railHeight, depth: railThickness, cornerRadius: 0.005)

--- a/CardPhysicsPackage/Sources/CardPhysicsKit/Scene/CardPhysicsScene.swift
+++ b/CardPhysicsPackage/Sources/CardPhysicsKit/Scene/CardPhysicsScene.swift
@@ -49,6 +49,7 @@ public struct CardPhysicsScene: View {
     @State internal var cardSideAssignments: [ObjectIdentifier: Int] = [:]
     @State internal var deckPosition = Entity()
     @State internal var handEntities: [Entity] = []
+    @State internal var cardsInFanState: Bool = false
     @State internal var lastRoomEnvironment: RoomEnvironment = .none
     @State internal var lastCustomRoomImageFilename: String = ""
     @State internal var lastRoomRotation: Double = 0.0
@@ -245,6 +246,8 @@ public struct CardPhysicsScene: View {
 
 
     public func resetCards() {
+        cardsInFanState = false
+
         // Remove all cards and recreate deck
         for card in cards {
             card.removeFromParent()

--- a/CardPhysicsPackage/Tests/CardPhysicsKitTests/CollisionUtilsTests.swift
+++ b/CardPhysicsPackage/Tests/CardPhysicsKitTests/CollisionUtilsTests.swift
@@ -1,0 +1,145 @@
+import Testing
+import RealityKit
+@testable import CardPhysicsKit
+
+// MARK: - TableGeometry Tests
+
+@Test @MainActor func tableGeometrySymmetry() {
+    #expect(TableGeometry.feltSurfaceY > 0)
+    #expect(TableGeometry.innerMinX < 0)
+    #expect(TableGeometry.innerMaxX > 0)
+    #expect(TableGeometry.innerMinX == -TableGeometry.innerMaxX)
+    #expect(TableGeometry.innerMinZ == -TableGeometry.innerMaxZ)
+}
+
+// MARK: - Y Validation Tests
+
+@Test @MainActor func flatCardAtOriginIsRaisedAboveFelt() {
+    let transform = Transform(translation: [0, 0, 0])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0
+    )
+    #expect(safe.translation.y >= TableGeometry.feltSurfaceY)
+}
+
+@Test @MainActor func cardAboveTableIsNotMoved() {
+    let transform = Transform(translation: [0, 0.2, 0])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0
+    )
+    #expect(safe.translation.y == 0.2)
+}
+
+@Test @MainActor func tiltedCardNeedsMoreClearanceThanFlat() {
+    let flatTransform = Transform(translation: [0, 0, 0])
+    let flatSafe = CollisionUtils.validateCardTransform(
+        flatTransform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0
+    )
+
+    let tiltedRotation = simd_quatf(angle: .pi / 4, axis: [1, 0, 0])
+    let tiltedTransform = Transform(rotation: tiltedRotation, translation: [0, 0, 0])
+    let tiltedSafe = CollisionUtils.validateCardTransform(
+        tiltedTransform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0
+    )
+
+    #expect(tiltedSafe.translation.y > flatSafe.translation.y)
+}
+
+@Test @MainActor func curvedCardCenterIsValidated() {
+    // A curved card low to the table should be raised because curvature
+    // pushes the center downward
+    let transform = Transform(translation: [0, 0.01, 0])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: -0.015
+    )
+    #expect(safe.translation.y > transform.translation.y)
+}
+
+// MARK: - Boundary Clamping Tests
+
+@Test @MainActor func cardPastLeftRailIsClampedInward() {
+    let transform = Transform(translation: [-0.7, 0.05, 0])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0,
+        clampToBounds: true
+    )
+
+    let (c0, c1, c2, c3) = CollisionUtils.cardCornerPositions(
+        transform: safe,
+        cardWidth: CardEntity3D.cardWidth,
+        cardDepth: CardEntity3D.cardDepth
+    )
+    let minX = min(min(c0.x, c1.x), min(c2.x, c3.x))
+    #expect(minX >= TableGeometry.innerMinX)
+}
+
+@Test @MainActor func cardPastBottomRailIsClampedInward() {
+    let transform = Transform(translation: [0, 0.05, 0.6])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0,
+        clampToBounds: true
+    )
+
+    let (c0, c1, c2, c3) = CollisionUtils.cardCornerPositions(
+        transform: safe,
+        cardWidth: CardEntity3D.cardWidth,
+        cardDepth: CardEntity3D.cardDepth
+    )
+    let maxZ = max(max(c0.z, c1.z), max(c2.z, c3.z))
+    #expect(maxZ <= TableGeometry.innerMaxZ)
+}
+
+@Test @MainActor func cardInsideBoundsIsNotClamped() {
+    let transform = Transform(translation: [0.1, 0.05, -0.1])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0,
+        clampToBounds: true
+    )
+    #expect(safe.translation.x == transform.translation.x)
+    #expect(safe.translation.z == transform.translation.z)
+}
+
+@Test @MainActor func clampToBoundsDefaultsToFalse() {
+    // Without clampToBounds, card past rail should NOT be clamped
+    let transform = Transform(translation: [-0.7, 0.05, 0])
+    let safe = CollisionUtils.validateCardTransform(
+        transform,
+        cardWidth: CardEntity3D.cardWidth,
+        cardHeight: CardEntity3D.cardHeight,
+        cardDepth: CardEntity3D.cardDepth,
+        curvature: 0.0
+    )
+    #expect(safe.translation.x == transform.translation.x)
+}


### PR DESCRIPTION
## Summary
- Removed `opacityThreshold = 0.5` from card PBR materials — this was causing hard cutoffs where transparent texture pixels became invisible
- Made card textures fully opaque by adding `.background(Color.white)` to SwiftUI renders and removing the `applyRoundedCornerMask()` that created transparent corners
- Includes world-space fan refactoring (#49): safe movement validation, collision utilities, and TableGeometry constants
- Added UI test (`testCaptureInHandsFan`) for visual regression testing of the fan state

## Test plan
- [x] Build succeeds on iOS simulator and physical device
- [x] UI test passes: Deal → Fan in Hands captures screenshot without clipping
- [x] Installed and launched on physical iPhone

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)